### PR TITLE
[COOK-1759] Add missing rhel platform_family package for git::source installation

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -19,7 +19,7 @@
 include_recipe "build-essential"
 
 pkgs = value_for_platform_family(
-  ["rhel"] => %w{ expat-devel gettext-devel libcurl-devel openssl-devel zlib-devel }
+  ["rhel"] => %w{ expat-devel gettext-devel libcurl-devel openssl-devel perl-ExtUtils-MakeMaker zlib-devel }
 )
 
 pkgs.each do |pkg|


### PR DESCRIPTION
Should help for installations on base Amazon and CentOS boxes.
