### PR TITLE
install git on ubuntu not git-core

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,11 @@
 
 case node['platform_family']
 when "debian"
-  package "git-core"
+  if node['platform'] == "ubuntu"
+    package "git"
+  else
+    package "git-core"
+  end
 when "rhel","fedora"
   case node['platform_version'].to_i
   when 5


### PR DESCRIPTION
git-core is obsolete on ubuntu
rather install the package git

have check that git-core is obsolete on Ubuntu 10.10 and 12.04
