### PR TITLE
[COOK-2043] install git on ubuntu 12.04 not git-core

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,12 @@
 
 case node['platform_family']
 when "debian"
-  package "git-core"
+  if node['platform'] == "ubuntu" && node['lsb']['release'] == "12.04"
+    # ubuntu 12.04 renames git-core to git
+    package "git"
+  else
+    package "git-core"
+  end
 when "rhel","fedora"
   case node['platform_version'].to_i
   when 5


### PR DESCRIPTION
`apt-cache show git-core` on Ubuntu 12.04 LTS says:

This is a transitional dummy package.  The 'git-core' package has been
renamed to 'git', which has been installed automatically.  This
git-core package is now obsolete, and can safely be removed from the
system if no other package depends on it.
