### PR TITLE
[COOK-2043] Default to "git" on recent Debianoids

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,11 @@
 
 case node['platform_family']
 when "debian"
-  package "git-core"
+  if node['platform'] == "ubuntu" && node['platform_version'].to_f < 10.10
+    package "git-core"
+  else
+    package "git"
+  end
 when "rhel","fedora"
   case node['platform_version'].to_i
   when 5


### PR DESCRIPTION
Debian 6.0 "squeeze" and Ubuntu 10.10 "maverick" renamed the package to
"git" and git-core is a transitional dummy package. On some point it
will be removed.

Only install "git-core" on ancient Ubuntu versions as Debian 5.0 hasn't
been supported for a while. Ubuntu 10.04 LTS still is.

This is another angle to the pull request #11.
Ticket: http://tickets.opscode.com/browse/COOK-2043
