### PR TITLE
Add initial test-kitchen support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.bundle
+.cache
+.kitchen
+bin

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source :rubygems
+
+gem 'test-kitchen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,131 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    archive-tar-minitar (0.5.2)
+    builder (3.0.4)
+    bunny (0.7.9)
+    chef (10.16.2)
+      bunny (>= 0.6.0, < 0.8.0)
+      erubis
+      highline (>= 1.6.9)
+      json (>= 1.4.4, <= 1.6.1)
+      mixlib-authentication (>= 1.3.0)
+      mixlib-cli (>= 1.1.0)
+      mixlib-config (>= 1.1.2)
+      mixlib-log (>= 1.3.0)
+      mixlib-shellout
+      moneta
+      net-ssh (~> 2.2.2)
+      net-ssh-multi (~> 1.1.0)
+      ohai (>= 0.6.0)
+      rest-client (>= 1.0.4, < 1.7.0)
+      treetop (~> 1.4.9)
+      uuidtools
+      yajl-ruby (~> 1.1)
+    childprocess (0.3.6)
+      ffi (~> 1.0, >= 1.0.6)
+    coderay (1.0.8)
+    erubis (2.7.0)
+    excon (0.16.10)
+    ffi (1.2.0)
+    fog (1.8.0)
+      builder
+      excon (~> 0.14)
+      formatador (~> 0.2.0)
+      mime-types
+      multi_json (~> 1.0)
+      net-scp (~> 1.0.4)
+      net-ssh (>= 2.1.3)
+      nokogiri (~> 1.5.0)
+      ruby-hmac
+    foodcritic (1.6.1)
+      erubis
+      gherkin (~> 2.11.1)
+      gist (~> 3.1.0)
+      nokogiri (= 1.5.0)
+      pry (~> 0.9.8.4)
+      rak (~> 1.4)
+      treetop (~> 1.4.10)
+      yajl-ruby (~> 1.1.0)
+    formatador (0.2.4)
+    gherkin (2.11.5)
+      json (>= 1.4.6)
+    gist (3.1.0)
+    hashr (0.0.22)
+    highline (1.6.15)
+    i18n (0.6.1)
+    ipaddress (0.8.0)
+    json (1.5.4)
+    librarian (0.0.25)
+      archive-tar-minitar (>= 0.5.2)
+      chef (>= 0.10)
+      highline
+      thor (~> 0.15)
+    log4r (1.1.10)
+    method_source (0.7.1)
+    mime-types (1.19)
+    mixlib-authentication (1.3.0)
+      mixlib-log
+    mixlib-cli (1.2.2)
+    mixlib-config (1.1.2)
+    mixlib-log (1.4.1)
+    mixlib-shellout (1.1.0)
+    moneta (0.6.0)
+    multi_json (1.5.0)
+    net-scp (1.0.4)
+      net-ssh (>= 1.99.1)
+    net-ssh (2.2.2)
+    net-ssh-gateway (1.1.0)
+      net-ssh (>= 1.99.1)
+    net-ssh-multi (1.1)
+      net-ssh (>= 2.1.4)
+      net-ssh-gateway (>= 0.99.0)
+    nokogiri (1.5.0)
+    ohai (6.14.0)
+      ipaddress
+      mixlib-cli
+      mixlib-config
+      mixlib-log
+      systemu
+      yajl-ruby
+    polyglot (0.3.3)
+    pry (0.9.8.4)
+      coderay (~> 1.0.5)
+      method_source (~> 0.7.1)
+      slop (>= 2.4.4, < 3)
+    rak (1.4)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    ruby-hmac (0.4.0)
+    slop (2.4.4)
+    systemu (2.5.2)
+    test-kitchen (0.7.0)
+      fog
+      foodcritic (>= 1.4.0)
+      hashr (~> 0.0.20)
+      highline (>= 1.6.9)
+      librarian (~> 0.0.20)
+      mixlib-cli (~> 1.2.2)
+      vagrant (~> 1.0.2)
+      yajl-ruby (~> 1.1.0)
+    thor (0.16.0)
+    treetop (1.4.12)
+      polyglot
+      polyglot (>= 0.3.1)
+    uuidtools (2.1.3)
+    vagrant (1.0.5)
+      archive-tar-minitar (= 0.5.2)
+      childprocess (~> 0.3.1)
+      erubis (~> 2.7.0)
+      i18n (~> 0.6.0)
+      json (~> 1.5.1)
+      log4r (~> 1.1.9)
+      net-scp (~> 1.0.4)
+      net-ssh (~> 2.2.2)
+    yajl-ruby (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  test-kitchen

--- a/test/kitchen/Kitchenfile
+++ b/test/kitchen/Kitchenfile
@@ -1,0 +1,3 @@
+cookbook "git" do
+
+end


### PR DESCRIPTION
Ran `kitchen init`

Initial test-kitchen support for the Git cookbook. No mini-tests yet.

Ticket: http://tickets.opscode.com/browse/COOK-2110

Thanks,

Doug Ireton
Nordstrom
