### PR TITLE
Add git to the PATH for current chef-client run (on Windows)

### DIFF
--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -26,7 +26,9 @@ end
 # Git is installed to Program Files (x86) on 64-bit machines and
 # 'Program Files' on 32-bit machines
 PROGRAM_FILES = ENV['ProgramFiles(x86)'] || ENV['ProgramFiles']
+GIT_PATH = ";#{ PROGRAM_FILES }\\Git\\Cmd"
 
-windows_path "#{ PROGRAM_FILES }\\Git\\Cmd" do
+ENV['PATH'] += ";#{GIT_PATH}"
+windows_path GIT_PATH do
   action :add
 end


### PR DESCRIPTION
The windows_path resource doesn't change the current process' environment variables. Therefore, git won't actually be on the PATH until the next chef-client run. By directly modifying ENV, we allow git to be on the PATH during this chef-client run.

This is related to http://tickets.opscode.com/browse/CHEF-4408
