### PR TITLE
[COOK-3433] Use xinted for git-daemon on Debian and RHEL.

### DIFF
--- a/templates/default/git-xinetd.d.erb
+++ b/templates/default/git-xinetd.d.erb
@@ -4,7 +4,7 @@ service git
         socket_type     = stream
         wait            = no
         user            = nobody
-        server          = /usr/libexec/git-core/git-daemon
+        server          = <%= @git_daemon_binary %>
         server_args     = --base-path=<%= node["git"]["server"]["base_path"] %> <% if node["git"]["server"]["export_all"] == "true" %>--export-all <% end %>--syslog --inetd --verbose
         log_on_failure  += USERID
 }


### PR DESCRIPTION
Debian has a git-daemon-run package that provides a runit configuration,
however this package is not configurable to specify the base path for
the git daemon. The runit configuration in the package also conflicts
with runit configuration that could be generated by the runit cookbook
(vi sv_template = true). So using the git-daemon-run package there isn't
an easy way to set the git daemon base path from chef.

A simple resolution is to use xinetd on both platforms. Then the same
template can be used to ensure that the base path is correctly set for
the git daemon.

This commit adds a single variable to the xinetd service template to
allow for different binary locations across platforms.

http://tickets.opscode.com/browse/COOK-3433
