### PR TITLE
[COOK-3624] Restart xinetd only when needed.

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -46,10 +46,11 @@ when "rhel"
     owner "root"
     group "root"
     mode 00644
+    notifies :restart, "service[xinetd]"
   end
 
   service "xinetd" do
-    action [:enable, :restart]
+    action [:enable, :start]
   end
 else
   log "Platform requires setting up a git daemon service script."


### PR DESCRIPTION
Restart xinetd only when a restart is needed.

https://tickets.opscode.com/browse/COOK-3624
