### PR TITLE
Removed `creates` from `execute` block

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -44,6 +44,5 @@ execute "Extracting and Building Git #{node['git']['version']} from Source" do
     (mkdir git-#{node['git']['version']} && tar -zxf git-#{node['git']['version']}.tar.gz -C git-#{node['git']['version']} --strip-components 1)
     (cd git-#{node['git']['version']} && make prefix=#{node['git']['prefix']} install)
   COMMAND
-  creates "#{node['git']['prefix']}/bin/git"
   not_if "git --version | grep #{node['git']['version']}"
 end


### PR DESCRIPTION
Removed `creates` from `execute` block which was blocking any potential upgrade from source. Fixes https://tickets.opscode.com/browse/COOK-4064
