### PR TITLE
[COOK-4146] fix compile dependencies for git::source

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -19,7 +19,7 @@
 return "#{node['platform']} is not supported by the #{cookbook_name}::#{recipe_name} recipe" if node['platform'] == 'windows'
 
 include_recipe 'build-essential'
-include_recipe 'yum-epel' if node['platform_family'] == 'rhel'
+include_recipe 'yum-epel' if node['platform_family'] == 'rhel' && node['platform_version'].to_i < 6
 
 # move this to attributes.
 case node['platform_family']


### PR DESCRIPTION
This addresses https://tickets.opscode.com/browse/COOK-4146 - issues with prerequisite packages for compiling git from source on red-hat.
- fixed package name `curl-devel` -> `libcurl-devel`
- don't include `yum-epel` for rhel versions < 6
