### PR TITLE
adding git to windows path unless already there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ git Cookbook CHANGELOG
 This file is used to list changes made in each version of the git cookbook.
 
 
+v2.9.1
+------
+Updating to only add GIT_PATH once in git::windows
+
+
 v2.9.0
 ------
 Updating to depend on cookbook yum ~> 3

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -31,7 +31,8 @@ GIT_PATH = ";#{ PROGRAM_FILES }\\Git\\Cmd"
 # COOK-3482 - windows_path resource doesn't change the current process
 # environment variables. Therefore, git won't actually be on the PATH
 # until the next chef-client run
-ENV['PATH'] += ";#{GIT_PATH}"
+ENV['PATH'] += ";#{GIT_PATH}" unless ENV['PATH'].include?(GIT_PATH)
 windows_path GIT_PATH do
   action :add
+  not_if { ENV['PATH'].include?(GIT_PATH) }
 end


### PR DESCRIPTION
I found that after multiple executions of the recipe that ENV['PATH'] had numerous copies of GIT_PATH.
