### PR TITLE
[COOK-4397] Syntax error in provider config.

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -1,4 +1,4 @@
-use_inline_resources
+use_inline_resources if defined?(use_inline_resources)
 
 def whyrun_supported?
   true


### PR DESCRIPTION
use_inline_resources might be undefined. Therefore it should only be used if defined.
