### PR TITLE
Adding set_git_config matcher for ChefSpec

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,5 @@
+if defined?(ChefSpec)
+  def set_git_config(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:git_config, :set, resource_name)
+  end
+end


### PR DESCRIPTION
Developers need to test git_config calls in their ChefSpec.
