### PR TITLE
Update versions for windows and linux

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,9 +32,9 @@ when 'mac_os_x'
   default['git']['osx_dmg']['checksum']    = 'e1d0ec7a9d9d03b9e61f93652b63505137f31217908635cdf2f350d07cb33e15'
 else
   default['git']['prefix'] = '/usr/local'
-  default['git']['version'] = '1.8.2.1'
+  default['git']['version'] = '1.9.4'
   default['git']['url'] = "https://nodeload.github.com/git/git/tar.gz/v#{node['git']['version']}"
-  default['git']['checksum'] = 'bdc1768f70ce3d8f3e4edcdcd99b2f85a7f8733fb684398aebe58dde3e6bcca2'
+  default['git']['checksum'] = '6459745c887ce583f9006e0e27320b27438656409d70e210000800bfd6d3059d'
 end
 
 default['git']['server']['base_path'] = '/srv/git'


### PR DESCRIPTION
This is important because the old download location for
windows no longer works (returns 404).

Closes: #22
