### PR TITLE
Add options for windows installer to enable passing arguments such as…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,7 @@ when 'windows'
   if node['kernel']['machine'] == 'x86_64'
     default['git']['architecture'] = '64'
     default['git']['checksum'] = '5e5283990cc91d1e9bd0858f8411e7d0afb70ce26e23680252fb4869288c7cfb'
+    default['git']['options'] = nil
   else
     default['git']['architecture'] = '32'
     default['git']['checksum'] = '17418c2e507243b9c98db161e9e5e8041d958b93ce6078530569b8edaec6b8a4'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -43,5 +43,9 @@ module GitCookbook
       return new_resource.windows_package_checksum if new_resource.windows_package_checksum
       '49601d5102df249d6f866ecfa1eea68eb5672acc1dbb7e4051099e792f6da5fc'
     end
+    
+    def parsed_git_options
+      return new_resource.git_options
+     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -45,7 +45,7 @@ module GitCookbook
     end
     
     def parsed_git_options
-      return new_resource.git_options
+      new_resource.git_options
      end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -43,9 +43,5 @@ module GitCookbook
       return new_resource.windows_package_checksum if new_resource.windows_package_checksum
       '49601d5102df249d6f866ecfa1eea68eb5672acc1dbb7e4051099e792f6da5fc'
     end
-    
-    def git_options
-      return new_resource.git_options
-    end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -45,7 +45,7 @@ module GitCookbook
     end
     
     def parsed_git_options
-      new_resource.git_options
+      new_resource.git_options if new_resource.git_options
      end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -43,5 +43,9 @@ module GitCookbook
       return new_resource.windows_package_checksum if new_resource.windows_package_checksum
       '49601d5102df249d6f866ecfa1eea68eb5672acc1dbb7e4051099e792f6da5fc'
     end
+    
+    def git_options
+      return new_resource.git_options
+    end
   end
 end

--- a/libraries/provider_git_client_windows.rb
+++ b/libraries/provider_git_client_windows.rb
@@ -13,7 +13,7 @@ class Chef
             source parsed_windows_package_url
             checksum parsed_windows_package_checksum
             installer_type :inno
-            options git_options
+            options parsed_git_options
           end
 
           # Git is installed to Program Files (x86) on 64-bit machines and

--- a/libraries/provider_git_client_windows.rb
+++ b/libraries/provider_git_client_windows.rb
@@ -13,6 +13,7 @@ class Chef
             source parsed_windows_package_url
             checksum parsed_windows_package_checksum
             installer_type :inno
+            options git_options
           end
 
           # Git is installed to Program Files (x86) on 64-bit machines and

--- a/libraries/resource_git_client.rb
+++ b/libraries/resource_git_client.rb
@@ -33,6 +33,7 @@ class Chef
       attribute :windows_package_url,  kind_of: String, default: nil
       attribute :windows_package_checksum, kind_of: String, default: nil
       attribute :windows_package_version, kind_of: String, default: nil
+      attribute :git_options, kind_of: String, default: nil
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs git and/or sets up a Git server daemon'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '8.0.2'
+version '8.0.3'
 recipe 'git', 'Installs git'
 recipe 'git::server', 'Sets up a a git daemon'
 recipe 'git::source', 'Installs git from source'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs git and/or sets up a Git server daemon'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '8.0.0'
+version '8.0.1'
 recipe 'git', 'Installs git'
 recipe 'git::server', 'Sets up a a git daemon'
 recipe 'git::source', 'Installs git from source'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs git and/or sets up a Git server daemon'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '8.0.1'
+version '8.0.2'
 recipe 'git', 'Installs git'
 recipe 'git::server', 'Sets up a a git daemon'
 recipe 'git::source', 'Installs git from source'

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -20,5 +20,6 @@ git_client 'default' do
   windows_display_name node['git']['display_name']
   windows_package_url format(node['git']['url'], version: node['git']['version'], architecture: node['git']['architecture'])
   windows_package_checksum node['git']['checksum']
+  git_options node['git']['options']
   action :install
 end


### PR DESCRIPTION
Add options for windows installer to enable passing arguments such as an INF file for silent install.

### Description

Allow for adding options for Windows installer. For example, it is possible to run installer in silent mode with '/LOADINF="filename"'

### Issues Resolved

Testing

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
