### PR TITLE
Fix Windows & MacOS GH CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
   integration-macos:
     needs: lint-unit
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       matrix:
         os: [macos-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         env:
           CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.exec.yml
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'  # allow path editing
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true  # allow path editing
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,16 +75,13 @@ jobs:
             sudo journalctl -l --since today
             KITCHEN_LOCAL_YAML=kitchen.dokken.yml /usr/bin/kitchen exec ${{ matrix.suite }}-${{ matrix.os }} -c "journalctl -l"
 
-  integration-macos:
+  integration-windows:
     needs: [mdl, yamllint, delivery]
-    runs-on: macos-latest
+    runs-on: windows-latest
     strategy:
       matrix:
         os:
-          - windows-2012r2
-          - windows-2016
-          - windows-2019
-          - macos-1015
+          - windows-latest
         suite:
           - resources
       fail-fast: false
@@ -98,6 +95,32 @@ jobs:
         uses: actionshub/test-kitchen@main
         env:
           CHEF_LICENSE: accept-no-persist
+          KITCHEN_LOCAL_YAML: kitchen.exec.yml
+        with:
+          suite: ${{ matrix.suite }}
+          os: ${{ matrix.os }}
+
+  integration-macos:
+    needs: [mdl, yamllint, delivery]
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+        suite:
+          - resources
+      fail-fast: false
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Chef
+        uses: actionshub/chef-install@main
+      - name: test-kitchen
+        uses: actionshub/test-kitchen@main
+        env:
+          CHEF_LICENSE: accept-no-persist
+          KITCHEN_LOCAL_YAML: kitchen.exec.yml
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
         env:
           CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.exec.yml
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'  # allow path editing
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,7 @@ name: ci
 "on":
   pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   lint-unit:
@@ -54,14 +53,12 @@ jobs:
             KITCHEN_LOCAL_YAML=kitchen.dokken.yml /usr/bin/kitchen exec ${{ matrix.suite }}-${{ matrix.os }} -c "journalctl -l"
 
   integration-windows:
-    needs: [mdl, yamllint, delivery]
+    needs: lint-unit
     runs-on: windows-latest
     strategy:
       matrix:
-        os:
-          - windows-latest
-        suite:
-          - resources
+        os: [windows-latest]
+        suite: [resources]
       fail-fast: false
 
     steps:
@@ -74,7 +71,7 @@ jobs:
         env:
           CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.exec.yml
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true  # allow path editing
+          # ACTIONS_ALLOW_UNSECURE_COMMANDS: true  # allow path editing
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}
@@ -84,12 +81,9 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        os:
-          - macos-latest
-        suite:
-          - resources
+        os: [macos-latest]
+        suite: [resources]
       fail-fast: false
-
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix Windows/MacOS CI testing
+
 ## 11.0.1 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,10 +1,9 @@
 ---
 driver:
   name: dokken
-  privileged: true  # because Docker and SystemD
+  privileged: true
 
-transport:
-  name: dokken
+transport: { name: dokken }
 
 provisioner:
   name: dokken

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -1,0 +1,14 @@
+---
+driver:
+  name: exec
+
+transport:
+  name: exec
+
+provisioner:
+  name: chef_zero
+  deprecations_as_errors: true
+
+platforms:
+  - name: windows-latest
+  - name: macos-latest

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -1,13 +1,6 @@
 ---
-driver:
-  name: exec
-
-transport:
-  name: exec
-
-provisioner:
-  name: chef_zero
-  deprecations_as_errors: true
+driver: { name: exec }
+transport: { name: exec }
 
 platforms:
   - name: windows-latest

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  product_name: chef
+  product_name: cinc
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
@@ -28,14 +28,29 @@ platforms:
     driver:
       box: tas50/windows_2012r2
       gui: false
+      customize:
+        memory: 2048
+    transport:
+      name: winrm
+      elevated: true
   - name: windows-2016
     driver:
       box: tas50/windows_2016
       gui: false
+      customize:
+        memory: 2048
+    transport:
+      name: winrm
+      elevated: true
   - name: windows-2019
     driver:
       box: tas50/windows_2019
       gui: false
+      customize:
+        memory: 2048
+    transport:
+      name: winrm
+      elevated: true
   - name: macos-10.15
     run_list: homebrew::default
     driver:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,9 +4,10 @@ driver:
 
 provisioner:
   name: chef_zero
-  product_name: cinc
-  enforce_idempotency: true
+  product_name: chef
+  chef_license: accept-no-persist
   multiple_converge: 2
+  enforce_idempotency: true
   deprecations_as_errors: true
 
 verifier:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,6 +1,5 @@
 ---
-driver:
-  name: vagrant
+driver: { name: vagrant }
 
 provisioner:
   name: chef_infra
@@ -10,8 +9,7 @@ provisioner:
   enforce_idempotency: true
   deprecations_as_errors: true
 
-verifier:
-  name: inspec
+verifier: { name: inspec }
 
 platforms:
   - name: amazonlinux-2

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -36,7 +36,7 @@ module GitCookbook
 
     def parsed_windows_package_url
       return new_resource.windows_package_url if new_resource.windows_package_url
-      "https://github.com/git-for-windows/git/releases/download/v%#{parsed_windows_package_version}.windows.1/Git-%#{parsed_windows_package_version}-32-bit.exe"
+      "https://github.com/git-for-windows/git/releases/download/v#{parsed_windows_package_version}.windows.1/Git-#{parsed_windows_package_version}-32-bit.exe"
     end
 
     def parsed_windows_package_checksum

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -2,9 +2,11 @@ apt_update
 
 git_client 'install it'
 
+user_path = platform_family?('windows') ? 'C:\Users\random' : '/home/random'
+
 user 'random' do
   manage_home true
-  home '/home/random'
+  home user_path
 end
 
 git_config 'add name to random' do
@@ -14,8 +16,8 @@ git_config 'add name to random' do
   value 'John Doe global'
 end
 
-git '/home/random/git_repo' do
-  repository 'https://github.com/chef/chef-repo.git'
+git "#{user_path}/git_repo" do
+  repository 'https://github.com/chef-boneyard/chef-repo.git'
   user 'random'
 end
 
@@ -24,7 +26,7 @@ git_config 'change local path' do
   scope 'local'
   key 'user.name'
   value 'John Doe local'
-  path '/home/random/git_repo'
+  path "#{user_path}/git_repo"
 end
 
 git_config 'change system config' do


### PR DESCRIPTION
# Description

Since these VMs don't need to reboot, run tests directly on the runner instead of using a nested VM.

This should fix the testing failures with the Windows and MacOS testing from #143.

Signed-off-by: Robert Detjens <detjensrobert@osuosl.org>

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
