### PR TITLE
Fixed git checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix Windows default git checksum
+
 ## 11.1.0 - *2022-08-09*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,7 @@ if platform_family?('windows')
     default['git']['checksum'] = '5d66948e7ada0ab184b2745fdf6e11843443a97655891c3c6268b5985b88bf4f'
   else
     default['git']['architecture'] = '32'
-    default['git']['checksum'] = '17418c2e507243b9c98db161e9e5e8041d958b93ce6078530569b8edaec6b8a4'
+    default['git']['checksum'] = '5e45b1226b106dd241de0be0b350052afe53bd61dce80ac6044600dc85fbfa0b'
   end
   default['git']['url'] = 'https://github.com/git-for-windows/git/releases/download/v%{version}.windows.1/Git-%{version}-%{architecture}-bit.exe'
   default['git']['display_name'] = "Git version #{node['git']['version']}"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@ if platform_family?('windows')
   default['git']['version'] = '2.35.1'
   if node['kernel']['machine'] == 'x86_64'
     default['git']['architecture'] = '64'
-    default['git']['checksum'] = '5e5283990cc91d1e9bd0858f8411e7d0afb70ce26e23680252fb4869288c7cfb'
+    default['git']['checksum'] = '5d66948e7ada0ab184b2745fdf6e11843443a97655891c3c6268b5985b88bf4f'
   else
     default['git']['architecture'] = '32'
     default['git']['checksum'] = '17418c2e507243b9c98db161e9e5e8041d958b93ce6078530569b8edaec6b8a4'

--- a/spec/unit/recipes/windows_spec.rb
+++ b/spec/unit/recipes/windows_spec.rb
@@ -12,7 +12,7 @@ describe_recipe 'git::windows' do
     expect(chef_run).to install_git_client('default').with(
       windows_display_name: 'Git version 2.35.1',
       windows_package_url: 'https://github.com/git-for-windows/git/releases/download/v2.35.1.windows.1/Git-2.35.1-64-bit.exe',
-      windows_package_checksum: '5e5283990cc91d1e9bd0858f8411e7d0afb70ce26e23680252fb4869288c7cfb'
+      windows_package_checksum: '5d66948e7ada0ab184b2745fdf6e11843443a97655891c3c6268b5985b88bf4f'
     )
   end
 end


### PR DESCRIPTION
# Description

Fixed windows git checksum from https://github.com/git-for-windows/git/releases/tag/v2.35.1.windows.1
Obvious fix.

## Issues Resolved



## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
